### PR TITLE
chore: upgrade pnpm to 11

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,13 +29,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -62,13 +55,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -101,13 +87,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -137,13 +116,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,13 +35,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,4 @@
-.npmrcengine-strict=true
-save-exact=true
-save-prefix=
-strict-peer-dependencies=false
-auto-install-peers=false
+# We do not use npm, but if it was ever run by accident, this should make sure that pre- and post-install scripts will
+# NOT run. This is more or less in line with pnpm behaviour where pre- and post-install scripts need to be added using
+# pnpm approve-builds
+ignore-scripts=true

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "xml"
   ],
   "private": true,
-  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
+  "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485",
   "engines": {
     "//": "Update @types/node to match the highest node version here",
     "node": ">=24 <=25",
-    "pnpm": "^10.17.0"
+    "pnpm": "^11.4.0"
   },
   "repository": {
     "type": "git+ssh",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+allowBuilds:
+  esbuild: true
+engineStrict: true
+saveExact: true
+savePrefix: ""
+strictPeerDependencies: false
+autoInstallPeers: false


### PR DESCRIPTION
This PR upgrades pnpm to the latest version.  pnpm 11 has been out for a while now, and is now the recommended version to use.  Set the minimum version to 11.4 since that is the latest version with security fixes.  To use pnpm 11, ensure you're on a recent version of Node and run `corepack enable` in the root of the repository.

```sh
# to use the version of pnpm as specified in package.json
corepack enable
```

[pnpm 11](https://pnpm.io/blog/releases/11.0#highlights) comes with breaking changes and the [migration guide](https://pnpm.io/migration) was used.  It comes with better defaults for [strictDepBuilds](https://pnpm.io/settings#strictdepbuilds): you must now explicitly review which build scripts are allowed.  As well as `blockExoticSubdeps`.

The automigration moved all properties from `.npmrc` to `pnpm-workspace.yaml`, but we want to keep `ignore-scripts` as a safety measure and `provenance` because changeset publish bypasses pnpm.

`minimumReleaseAge` by default is now 24h, same as our existing setting.  I still kept it in `pnpm-workspace.yaml`, as it doesn't hurt to be explicit about it.

Also cleaned up the workaround in pipelines that allowed an RC version of pnpm to be used when the npm audit endpoint was down.  With pnpm 11, this is no longer needed.
